### PR TITLE
Bugfix: Recorder and generator threads closing

### DIFF
--- a/example/lib/cubit/receive_tab_cubit/receive_tab_cubit.dart
+++ b/example/lib/cubit/receive_tab_cubit/receive_tab_cubit.dart
@@ -44,14 +44,15 @@ class ReceiveTabCubit extends Cubit<AReceiveTabState> {
     }
   }
 
-  void _handleRecordingCompleted() {
-    emit(ReceiveTabResultState(decodedMessage: (state as ReceiveTabRecordingState).decodedMessage));
+  void _handleRecordingCompleted(FrameCollectionModel frameCollectionModel) {
+    String decodedMessage = frameCollectionModel.mergedRawData;
+    emit(ReceiveTabResultState(decodedMessage: decodedMessage));
   }
 
   void _handleFrameReceived(FrameModel frameModel) {
     String decodedMessage = frameModel.rawData;
-    if (state is ReceiveTabResultState) {
-      decodedMessage = '${(state as ReceiveTabResultState).decodedMessage}$decodedMessage';
+    if (state is ReceiveTabRecordingState) {
+      decodedMessage = '${(state as ReceiveTabRecordingState).decodedMessage}$decodedMessage';
     }
     emit(ReceiveTabRecordingState(decodedMessage: decodedMessage));
   }

--- a/lib/mrumru.dart
+++ b/lib/mrumru.dart
@@ -88,6 +88,7 @@ export 'package:mrumru/src/audio/recorder/audio_recorder_controller.dart';
 ///
 ///   ```
 export 'package:mrumru/src/shared/models/audio_settings_model.dart';
+export 'package:mrumru/src/shared/models/frame/frame_collection_model.dart';
 
 /// Provides model of frame used to encode and decode data.
 ///

--- a/lib/src/audio/generator/audio_generator.dart
+++ b/lib/src/audio/generator/audio_generator.dart
@@ -3,7 +3,6 @@ import 'package:mrumru/mrumru.dart';
 import 'package:mrumru/src/audio/generator/sample_generator.dart';
 import 'package:mrumru/src/audio/generator/samples_processor.dart';
 import 'package:mrumru/src/frame/frame_model_builder.dart';
-import 'package:mrumru/src/shared/models/frame/frame_collection_model.dart';
 import 'package:mrumru/src/shared/models/sample_model.dart';
 
 /// A class that generates audio signals from text messages using Frequency Shift Keying (FSK).
@@ -56,7 +55,7 @@ class AudioGenerator {
   /// Stops the audio generation process and kills the audio sink.
   Future<void> stop() async {
     await _audioSink.kill();
-    _samplesProcessor.kill();
+    _samplesProcessor.close();
   }
 
   /// This method parses the text message into binary data.

--- a/lib/src/audio/generator/samples_processor.dart
+++ b/lib/src/audio/generator/samples_processor.dart
@@ -13,7 +13,7 @@ class SamplesProcessor {
   /// This method processes the samples list into wave and returns the wave samples.
   Future<void> processSamples({required List<SampleModel> samplesList, required SampleCreatedCallback onSampleCreated}) async {
     _streamIsolate = await StreamIsolate.spawn(() {
-      return _processSamplesThread(samplesList);
+      return _processSamplesThread(List<SampleModel>.from(samplesList));
     });
     await for (Float32List sample in _streamIsolate!.stream) {
       onSampleCreated(sample);
@@ -21,9 +21,9 @@ class SamplesProcessor {
     _streamIsolate = null;
   }
 
-  /// Kills the stream.
-  void kill() {
-    _streamIsolate?.kill();
+  /// Close the stream isolate.
+  void close() {
+    _streamIsolate?.close();
   }
 
   /// This method processes the samples list into wave.

--- a/lib/src/audio/recorder/audio_recorder_controller.dart
+++ b/lib/src/audio/recorder/audio_recorder_controller.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-
 import 'package:flutter/foundation.dart';
 import 'package:mrumru/mrumru.dart';
 import 'package:mrumru/src/audio/recorder/packet_recognizer.dart';
@@ -11,7 +10,7 @@ import 'package:wav/wav.dart';
 class AudioRecorderController {
   final AudioRecorder audioRecorder = AudioRecorder();
   final ValueChanged<FrameModel>? onFrameReceived;
-  final VoidCallback onRecordingCompleted;
+  final ValueChanged<FrameCollectionModel> onRecordingCompleted;
   final AudioSettingsModel audioSettingsModel;
   final FrameSettingsModel frameSettingsModel;
   late final PacketRecognizer packetRecognizer;
@@ -48,11 +47,11 @@ class AudioRecorderController {
     packetRecognizer.stopRecording();
   }
 
-  Future<void> _completeDecoding() async {
+  Future<void> _completeDecoding(FrameCollectionModel frameCollectionModel) async {
     if (await audioRecorder.isRecording()) {
       await audioRecorder.stop();
       await recordingStreamSubscription?.cancel();
-      onRecordingCompleted();
+      onRecordingCompleted(frameCollectionModel);
     }
   }
 

--- a/lib/src/audio/recorder/packet_recognizer.dart
+++ b/lib/src/audio/recorder/packet_recognizer.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-
 import 'package:flutter/foundation.dart';
 import 'package:mrumru/mrumru.dart';
 import 'package:mrumru/src/audio/recorder/correlation/start_index_correlation_calculator.dart';
@@ -7,29 +6,31 @@ import 'package:mrumru/src/audio/recorder/queue/events/packet_received_event.dar
 import 'package:mrumru/src/audio/recorder/queue/events/packet_remaining_event.dart';
 import 'package:mrumru/src/audio/recorder/queue/packet_event_queue.dart';
 import 'package:mrumru/src/frame/frame_model_decoder.dart';
-import 'package:mrumru/src/shared/models/frame/frame_collection_model.dart';
 import 'package:mrumru/src/shared/models/sample_model.dart';
 import 'package:mrumru/src/shared/utils/app_logger.dart';
 import 'package:mrumru/src/shared/utils/log_level.dart';
 
 class PacketRecognizer {
-  final Completer<bool> _decodingCompleter = Completer<bool>();
-  final PacketEventQueue _packetsQueue = PacketEventQueue();
+  static const Duration _nextActionWaitingDuration = Duration(milliseconds: 100);
 
-  final AudioSettingsModel audioSettingsModel;
-  final VoidCallback onDecodingCompleted;
+  final PacketEventQueue _packetsQueue = PacketEventQueue();
+  final AudioSettingsModel _audioSettingsModel;
+  final ValueChanged<FrameCollectionModel> _onDecodingCompleted;
+
   late final FrameModelDecoder _frameModelDecoder;
+  late Completer<bool> _processLoopCompleter;
 
   bool _recordingBool = false;
   int? _startOffset;
   int? _endOffset;
 
   PacketRecognizer({
-    required this.audioSettingsModel,
-    required this.onDecodingCompleted,
+    required AudioSettingsModel audioSettingsModel,
+    required void Function(FrameCollectionModel) onDecodingCompleted,
     required FrameSettingsModel frameSettingsModel,
     ValueChanged<FrameModel>? onFrameDecoded,
-  }) {
+  })  : _audioSettingsModel = audioSettingsModel,
+        _onDecodingCompleted = onDecodingCompleted {
     _frameModelDecoder = FrameModelDecoder(
       framesSettingsModel: frameSettingsModel,
       onFirstFrameDecoded: _handleFirstFrameDecoded,
@@ -41,8 +42,15 @@ class PacketRecognizer {
   FrameCollectionModel get decodedContent => _frameModelDecoder.decodedContent;
 
   Future<void> startDecoding() async {
+    _processLoopCompleter = Completer<bool>();
     _recordingBool = true;
-    while (_packetsQueue.isLongerThan(audioSettingsModel.sampleSize) || _recordingBool) {
+
+    while (_recordingBool) {
+      if (_packetsQueue.isLongerThan(_audioSettingsModel.sampleSize) == false) {
+        await Future<void>.delayed(_nextActionWaitingDuration);
+        continue;
+      }
+
       if (_startOffset == null) {
         await _tryFindStartOffset();
       } else {
@@ -50,7 +58,7 @@ class PacketRecognizer {
       }
     }
 
-    _decodingCompleter.complete(true);
+    _processLoopCompleter.complete(true);
   }
 
   void addPacket(PacketReceivedEvent packetReceivedEvent) {
@@ -60,26 +68,34 @@ class PacketRecognizer {
 
   Future<void> stopRecording() async {
     _recordingBool = false;
-    await _decodingCompleter.future;
-    onDecodingCompleted();
+    await _processLoopCompleter.future;
+    _onDecodingCompleted(decodedContent);
+    _clear();
+  }
+
+  void _clear() {
+    _packetsQueue.clear();
+    _frameModelDecoder.clear();
+    _startOffset = null;
+    _endOffset = null;
   }
 
   void _handleFirstFrameDecoded(FrameModel frameModel) {
-    _endOffset = frameModel.calculateTransferWavLength(audioSettingsModel);
+    _endOffset = frameModel.calculateTransferWavLength(_audioSettingsModel);
     AppLogger().log(message: 'End offset found: $_endOffset', logLevel: LogLevel.debug);
   }
 
   Future<void> _tryFindStartOffset() async {
-    if (_packetsQueue.isLongerThan(audioSettingsModel.maxStartOffset)) {
+    if (_packetsQueue.isLongerThan(_audioSettingsModel.maxStartOffset)) {
       await _findStartOffset();
     } else {
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await Future<void>.delayed(_nextActionWaitingDuration);
     }
   }
 
   Future<void> _findStartOffset() async {
-    List<double> waveToProcess = await _packetsQueue.readWave(audioSettingsModel.maxStartOffset);
-    _startOffset = await compute(_computeStartOffset, <dynamic>[waveToProcess, audioSettingsModel]);
+    List<double> waveToProcess = await _packetsQueue.readWave(_audioSettingsModel.maxStartOffset);
+    _startOffset = await compute(_computeStartOffset, <dynamic>[waveToProcess, _audioSettingsModel]);
 
     List<double> remainingData = waveToProcess.sublist(_startOffset!);
     _packetsQueue.push(PacketRemainingEvent(remainingData));
@@ -87,16 +103,16 @@ class PacketRecognizer {
   }
 
   Future<void> _tryProcessWave() async {
-    if (_packetsQueue.isLongerThan(audioSettingsModel.sampleSize)) {
+    if (_packetsQueue.isLongerThan(_audioSettingsModel.sampleSize)) {
       await _processSampleWave();
     } else {
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await Future<void>.delayed(_nextActionWaitingDuration);
     }
   }
 
   Future<void> _processSampleWave() async {
-    List<double> sampleWave = await _packetsQueue.readWave(audioSettingsModel.sampleSize);
-    SampleModel sampleModel = SampleModel.fromWave(sampleWave, audioSettingsModel);
+    List<double> sampleWave = await _packetsQueue.readWave(_audioSettingsModel.sampleSize);
+    SampleModel sampleModel = SampleModel.fromWave(sampleWave, _audioSettingsModel);
     _frameModelDecoder.addBinaries(<String>[sampleModel.calcBinary()]);
   }
 }

--- a/lib/src/audio/recorder/queue/packet_event_queue.dart
+++ b/lib/src/audio/recorder/queue/packet_event_queue.dart
@@ -47,4 +47,8 @@ class PacketEventQueue {
       eventQueue.insert(0, packetEvent);
     }
   }
+
+  void clear() {
+    eventQueue.clear();
+  }
 }

--- a/lib/src/frame/frame_model_builder.dart
+++ b/lib/src/frame/frame_model_builder.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 
 import 'package:mrumru/mrumru.dart';
-import 'package:mrumru/src/shared/models/frame/frame_collection_model.dart';
 
 class FrameModelBuilder {
   final FrameSettingsModel frameSettingsModel;

--- a/lib/src/frame/frame_model_decoder.dart
+++ b/lib/src/frame/frame_model_decoder.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/cupertino.dart';
 import 'package:mrumru/mrumru.dart';
-import 'package:mrumru/src/shared/models/frame/frame_collection_model.dart';
 import 'package:mrumru/src/shared/utils/app_logger.dart';
 import 'package:mrumru/src/shared/utils/binary_utils.dart';
 import 'package:mrumru/src/shared/utils/log_level.dart';
@@ -33,7 +32,13 @@ class FrameModelDecoder {
   }
 
   FrameCollectionModel get decodedContent {
-    return FrameCollectionModel(_decodedFrames);
+    return FrameCollectionModel(List<FrameModel>.from(_decodedFrames));
+  }
+
+  void clear() {
+    _decodedFrames.clear();
+    _completeBinary.clear();
+    _cursor = 0;
   }
 
   void _decodeFrames() {
@@ -51,7 +56,6 @@ class FrameModelDecoder {
 
     try {
       FrameModel frameModel = FrameModel.fromBinaryString(frameBinary);
-
       _decodedFrames.add(frameModel);
       if (frameModel.frameIndex == 0) {
         onFirstFrameDecoded?.call(frameModel);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mrumru
 description: Data Over Audio
-version: 0.0.8
+version: 0.0.9
 publish_to: 'none'
 
 environment:

--- a/test/integration/audio_process_test.dart
+++ b/test/integration/audio_process_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mrumru/mrumru.dart';
 import 'package:mrumru/src/audio/recorder/packet_recognizer.dart';
 import 'package:mrumru/src/audio/recorder/queue/events/packet_received_event.dart';
-import 'package:mrumru/src/shared/models/frame/frame_collection_model.dart';
 import 'package:wav/wav.dart';
 
 void main() async {
@@ -19,11 +18,12 @@ void main() async {
       File actualWavFile = File('./test/integration/assets/mocked_wave_file.wav');
       String actualInputString = '123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~';
       AudioFileSink audioFileSink = AudioFileSink(actualWavFile);
+      late FrameCollectionModel actualFrameCollectionModel;
 
       PacketRecognizer actualPacketRecognizer = PacketRecognizer(
         audioSettingsModel: actualAudioSettingsModel,
         frameSettingsModel: actualFrameSettingsModel,
-        onDecodingCompleted: () {},
+        onDecodingCompleted: (FrameCollectionModel frameCollectionModel) => actualFrameCollectionModel = frameCollectionModel,
         onFrameDecoded: (FrameModel frameModel) {},
       );
 
@@ -47,8 +47,6 @@ void main() async {
         actualPacketRecognizer.addPacket(packetReceivedEvent);
         await Future<void>.delayed(const Duration(milliseconds: 100));
       }
-
-      FrameCollectionModel actualFrameCollectionModel = actualPacketRecognizer.decodedContent;
 
       // Assert
       FrameCollectionModel expectedFrameCollectionModel = FrameCollectionModel(

--- a/test/unit/audio/recorder/packet_recognizer_test.dart
+++ b/test/unit/audio/recorder/packet_recognizer_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mrumru/mrumru.dart';
 import 'package:mrumru/src/audio/recorder/packet_recognizer.dart';
 import 'package:mrumru/src/audio/recorder/queue/events/packet_received_event.dart';
-import 'package:mrumru/src/shared/models/frame/frame_collection_model.dart';
 
 import '../../../utils/test_utils.dart';
 
@@ -17,13 +16,18 @@ void main() async {
       AudioSettingsModel actualAudioSettingsModel = AudioSettingsModel.withDefaults().copyWith(chunksCount: 1);
       FrameSettingsModel actualFrameSettingsModel = FrameSettingsModel.withDefaults();
 
+      late FrameCollectionModel actualFrameCollectionModel;
+
       PacketRecognizer actualPacketRecognizer = PacketRecognizer(
         audioSettingsModel: actualAudioSettingsModel,
         frameSettingsModel: actualFrameSettingsModel,
-        onDecodingCompleted: () {},
+        onDecodingCompleted: (FrameCollectionModel frameCollectionModel) => actualFrameCollectionModel = frameCollectionModel,
         onFrameDecoded: (FrameModel frameModel) {},
       );
-      List<double> actualWave = await TestUtils.readAsDoubleFromFile(File('test/unit/audio/assets/mocked_audio_wave_chunks_count_1.txt'));
+
+      List<double> actualWave = await TestUtils.readAsDoubleFromFile(
+        File('test/unit/audio/assets/mocked_audio_wave_chunks_count_1.txt'),
+      );
 
       // Act
       List<PacketReceivedEvent> testEvents = _prepareTestEvents(actualAudioSettingsModel.sampleSize, actualWave);
@@ -35,13 +39,11 @@ void main() async {
         await Future<void>.delayed(const Duration(milliseconds: 100));
       }
 
-      FrameCollectionModel actualFrameCollectionModel = actualPacketRecognizer.decodedContent;
-
       // Assert
       FrameCollectionModel expectedFrameCollectionModel = FrameCollectionModel(
         <FrameModel>[
           FrameModel(frameIndex: 0, framesCount: 2, rawData: '1234', frameSettings: actualFrameSettingsModel),
-          FrameModel(frameIndex: 1, framesCount: 2, rawData: '5678', frameSettings: actualFrameSettingsModel)
+          FrameModel(frameIndex: 1, framesCount: 2, rawData: '5678', frameSettings: actualFrameSettingsModel),
         ],
       );
 
@@ -52,11 +54,12 @@ void main() async {
       // Arrange
       AudioSettingsModel actualAudioSettingsModel = AudioSettingsModel.withDefaults().copyWith(chunksCount: 2);
       FrameSettingsModel actualFrameSettingsModel = FrameSettingsModel.withDefaults();
+      late FrameCollectionModel actualFrameCollectionModel;
 
       PacketRecognizer actualPacketRecognizer = PacketRecognizer(
         audioSettingsModel: actualAudioSettingsModel,
         frameSettingsModel: actualFrameSettingsModel,
-        onDecodingCompleted: () {},
+        onDecodingCompleted: (FrameCollectionModel frameCollectionModel) => actualFrameCollectionModel = frameCollectionModel,
         onFrameDecoded: (FrameModel frameModel) {},
       );
       List<double> actualWave = await TestUtils.readAsDoubleFromFile(File('test/unit/audio/assets/mocked_audio_wave_chunks_count_2.txt'));
@@ -70,8 +73,6 @@ void main() async {
         actualPacketRecognizer.addPacket(packetReceivedEvent);
         await Future<void>.delayed(const Duration(milliseconds: 100));
       }
-
-      FrameCollectionModel actualFrameCollectionModel = actualPacketRecognizer.decodedContent;
 
       // Assert
       FrameCollectionModel expectedFrameCollectionModel = FrameCollectionModel(
@@ -88,11 +89,12 @@ void main() async {
       // Arrange
       AudioSettingsModel actualAudioSettingsModel = AudioSettingsModel.withDefaults().copyWith(chunksCount: 4);
       FrameSettingsModel actualFrameSettingsModel = FrameSettingsModel.withDefaults();
+      late FrameCollectionModel actualFrameCollectionModel;
 
       PacketRecognizer actualPacketRecognizer = PacketRecognizer(
         audioSettingsModel: actualAudioSettingsModel,
         frameSettingsModel: actualFrameSettingsModel,
-        onDecodingCompleted: () {},
+        onDecodingCompleted: (FrameCollectionModel frameCollectionModel) => actualFrameCollectionModel = frameCollectionModel,
         onFrameDecoded: (FrameModel frameModel) {},
       );
       List<double> actualWave = await TestUtils.readAsDoubleFromFile(File('test/unit/audio/assets/mocked_audio_wave_chunks_count_4.txt'));
@@ -106,9 +108,6 @@ void main() async {
         actualPacketRecognizer.addPacket(packetReceivedEvent);
         await Future<void>.delayed(const Duration(milliseconds: 100));
       }
-
-      FrameCollectionModel actualFrameCollectionModel = actualPacketRecognizer.decodedContent;
-
       // Assert
       FrameCollectionModel expectedFrameCollectionModel = FrameCollectionModel(
         <FrameModel>[
@@ -124,11 +123,12 @@ void main() async {
       // Arrange
       AudioSettingsModel actualAudioSettingsModel = AudioSettingsModel.withDefaults().copyWith(chunksCount: 8);
       FrameSettingsModel actualFrameSettingsModel = FrameSettingsModel.withDefaults();
+      late FrameCollectionModel actualFrameCollectionModel;
 
       PacketRecognizer actualPacketRecognizer = PacketRecognizer(
         audioSettingsModel: actualAudioSettingsModel,
         frameSettingsModel: actualFrameSettingsModel,
-        onDecodingCompleted: () {},
+        onDecodingCompleted: (FrameCollectionModel frameCollectionModel) => actualFrameCollectionModel = frameCollectionModel,
         onFrameDecoded: (FrameModel frameModel) {},
       );
       List<double> actualWave = await TestUtils.readAsDoubleFromFile(File('test/unit/audio/assets/mocked_audio_wave_chunks_count_8.txt'));
@@ -142,8 +142,6 @@ void main() async {
         actualPacketRecognizer.addPacket(packetReceivedEvent);
         await Future<void>.delayed(const Duration(milliseconds: 100));
       }
-
-      FrameCollectionModel actualFrameCollectionModel = actualPacketRecognizer.decodedContent;
 
       // Assert
       FrameCollectionModel expectedFrameCollectionModel = FrameCollectionModel(

--- a/test/unit/audio/recorder/queue/packet_event_queue_test.dart
+++ b/test/unit/audio/recorder/queue/packet_event_queue_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: cascade_invocations
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mrumru/src/audio/recorder/queue/events/a_packet_event.dart';
 import 'package:mrumru/src/audio/recorder/queue/events/packet_received_event.dart';
@@ -138,6 +140,21 @@ void main() {
     test('Should [throw EXCEPTION] if [queue EMPTY]', () {
       // Assert
       expect(() => actualPacketEventQueue.pop(), throwsA(isA<Exception>()));
+    });
+  });
+
+  group('Test of PacketEventQueue.clear()', () {
+    test('Should [clear list] containing queue events', () {
+      // Arrange
+      PacketReceivedEvent actualFirstPacket = PacketReceivedEvent(List<double>.filled(8, 0));
+      PacketReceivedEvent actualSecondPacket = PacketReceivedEvent(List<double>.filled(8, 1));
+      PacketEventQueue actualPacketEventQueue = PacketEventQueue(queue: <APacketEvent>[actualFirstPacket, actualSecondPacket]);
+
+      // Act
+      actualPacketEventQueue.clear();
+
+      // Assert
+      expect(actualPacketEventQueue.eventQueue.isEmpty, true);
     });
   });
 }

--- a/test/unit/frame/frame_model_builder_test.dart
+++ b/test/unit/frame/frame_model_builder_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mrumru/mrumru.dart';
 import 'package:mrumru/src/frame/frame_model_builder.dart';
-import 'package:mrumru/src/shared/models/frame/frame_collection_model.dart';
 
 void main() {
   late FrameModelBuilder actualFrameBuilder;

--- a/test/unit/frame/frame_model_decoder_test.dart
+++ b/test/unit/frame/frame_model_decoder_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mrumru/mrumru.dart';
 import 'package:mrumru/src/frame/frame_model_decoder.dart';
-import 'package:mrumru/src/shared/models/frame/frame_collection_model.dart';
 
 void main() {
   FrameSettingsModel actualFrameSettingsModel = FrameSettingsModel.withDefaults();
@@ -42,6 +41,15 @@ void main() {
       ]);
 
       expect(actualFrameCollectionModel, expectedFrameCollectionModel);
+    });
+
+    test('Should [clear FrameModelCollection] containing FrameModels', () {
+      // Act
+      actualFrameModelDecoder.clear();
+
+      // Assert
+      FrameCollectionModel expectedFrameCollectionModel = const FrameCollectionModel(<FrameModel>[]);
+      expect(actualFrameModelDecoder.decodedContent, expectedFrameCollectionModel);
     });
   });
 }

--- a/test/unit/shared/models/frame/frame_collection_model_test.dart
+++ b/test/unit/shared/models/frame/frame_collection_model_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mrumru/mrumru.dart';
-import 'package:mrumru/src/shared/models/frame/frame_collection_model.dart';
 
 void main() {
   final FrameSettingsModel actualFrameSettingsModel = FrameSettingsModel.withDefaults();


### PR DESCRIPTION
Branch provides fixes for process to prevent app from crashing after multiple use of emit/record and stop button.

List of changes:
- modified sample_processor.dart by changing stream "kill()" method to "close()", which disposes the stream and cancels all listeners, also modified return method to correctly pass values
- modified packet_recognizer.dart to properly terminate processes to improve stability
- modified frame_model_decoder.dart, packet_event_queue.dart, added "clear()" method for disposing data after decoding completed
- modified audio_stream_sink.dart, replaced Future<void>.delayed() with Timer to enable manual closing
- modified audio_recorder_controller.dart and receive_tab_cubit for returning the FrameCollectionModel instead of raw String
- modified mrumru.dart by adding frame_model_collection.dart as now it's returned outside library